### PR TITLE
Background for inherit and both envs.

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -8,7 +8,8 @@
     "describe": false,
     "it": false,
     "before": false,
-    "require": false
+    "require": false,
+    "module": true
   },
   "rules": {
     "quotes": [1, "single"],

--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,21 @@
+{
+  "env": {
+    "amd": 2,
+    "browser": 2,
+    "node": 2
+  },
+  "globals": {
+    "describe": false,
+    "it": false,
+    "before": false,
+    "require": false
+  },
+  "rules": {
+    "quotes": [1, "single"],
+    "indent": [2, 2],
+    "strict": [0, "global"],
+    "no-underscore-dangle": 0,
+    "no-use-before-define": 0,
+    "no-proto": 0
+  }
+}

--- a/src/PromisePipe.js
+++ b/src/PromisePipe.js
@@ -32,7 +32,7 @@ function PromisePipeFactory(){
     function result(data, context){
       context = context || {};
       // set Random PromisePipe call ID
-      augumentContext(context, '_pipecallId', Math.ceil(Math.random()*Math.pow(10,16)));
+      augumentContext(context, '_pipecallId', Math.ceil(Math.random() * Math.pow(10, 16)));
       // set current PromisePipe env
       augumentContext(context, '_env', PromisePipe.env);
       var _trace = {};
@@ -41,7 +41,7 @@ function PromisePipeFactory(){
 
       var toConcat = [sequence];
 
-      if(PromisePipe._mode == 'DEBUG') {
+      if(PromisePipe._mode === 'DEBUG') {
         var debugChain = {
           func: printDebug,
           _id: ID(),
@@ -59,7 +59,10 @@ function PromisePipeFactory(){
       var chain = [].concat.apply([], toConcat);
 
       chain = chain.map(bindTo(context).bindIt.bind(result)).map(function(fn){
-        if(!fn._env) fn._env = PromisePipe.env;
+        if(!fn._env) {
+          fn._env = PromisePipe.env;
+        }
+
         return fn;
       });
       // run the chain
@@ -68,7 +71,7 @@ function PromisePipeFactory(){
 
     function printDebug(data, context){
       var ln = context._trace[context._pipecallId].length;
-      printDebugChain(context._trace[context._pipecallId].slice(0, ln-1));
+      printDebugChain(context._trace[context._pipecallId].slice(0, ln - 1));
       return data;
     }
 
@@ -77,25 +80,32 @@ function PromisePipeFactory(){
         return fn._id;
       });
 
+      function showLevel(i, traceLog){
+        var item = traceLog[i];
+        var fnId = seqIds.indexOf(item.chainId);
+        var name = '';
+        if (!!~fnId) {
+          name = sequence[fnId].name || sequence[fnId]._name;
+        }
+        console.group('.then(' + name + ')[' + item.env + ']');
+        console.log('data', item.data && JSON.parse(item.data));
+        console.log('context', JSON.parse(item.context));
+        if(traceLog[i + 1]) {
+          showLevel(i + 1, traceLog);
+        }
+        console.groupEnd('.then(' + name + ')');
+      }
+
       if(console.group){
         showLevel(0, traceLog);
-        function showLevel(i, traceLog){
-          var item = traceLog[i];
-          var fnId = seqIds.indexOf(item.chainId);
-          var name = '';
-          if(!!~fnId) name = sequence[fnId].name || sequence[fnId]._name;
-          console.group(".then("+name+")["+item.env+"]");
-          console.log("data", item.data && JSON.parse(item.data));
-          console.log("context", JSON.parse(item.context));
-          if(traceLog[i + 1]) showLevel(i+1, traceLog);
-          console.groupEnd(".then("+name+")");
-        }
       } else {
         traceLog.forEach(function(item, i){
-          var shift = new Array(i*4+1).join(" ");
+          var shift = new Array(i * 4 + 1).join('');
           var fnId = seqIds.indexOf(item.chainId);
           var name = '';
-          if(!!~fnId) name = sequence[fnId].name;
+          if(!!~fnId) {
+            name = sequence[fnId].name;
+          }
 
           console.log(shift + ".then("+name+")["+item.env+"]");
           console.log(shift + "    data    : " + JSON.stringify(item.data));

--- a/src/PromisePipe.js
+++ b/src/PromisePipe.js
@@ -315,7 +315,7 @@ function PromisePipeFactory(){
         return ctx._env !== funcArr._env && ctx._passChains && !!~ctx._passChains.indexOf(funcArr._id);
       },
       handler: function (sequence, data, pipe, ctx, doWork) {
-        return doWork.then(function () {
+        return doWork.then(function (data) {
           return data;
         });
       }

--- a/src/PromisePipe.js
+++ b/src/PromisePipe.js
@@ -294,9 +294,17 @@ function PromisePipeFactory(){
 
         return doWork.then(function (data) {
           var msg = PromisePipe.createTransitionMessage(data, ctx, pipe._id, funcArr._id, sequence[range[1]]._id, ctx._pipecallId);
-          console.log(msg);
+
           return PromisePipe.envTransitions[ctx._env][funcArr._env].call(this, msg);
         });
+      }
+    },
+    'both': {
+      predicate: function (sequence, data, pipe, ctx, funcArr) {
+        return funcArr._env === 'both';
+      },
+      handler: function () {
+        console.log('both handler');
       }
     },
     'inherit-pipe': {
@@ -312,7 +320,7 @@ function PromisePipeFactory(){
      */
     'inherit': {
       predicate: function (sequence, data, pipe, ctx, funcArr) {
-        return ctx._env !== funcArr._env && ctx._passChains && !!~ctx._passChains.indexOf(funcArr._id);
+        return funcArr._env === 'inherit' || (ctx._env !== funcArr._env && ctx._passChains && !!~ctx._passChains.indexOf(funcArr._id));
       },
       handler: function (sequence, data, pipe, ctx, doWork) {
         return doWork.then(function (data) {
@@ -411,6 +419,7 @@ function PromisePipeFactory(){
     if(!PromisePipe.envTransitions[from]) {
       PromisePipe.envTransitions[from] = {};
     }
+
     PromisePipe.envTransitions[from][to] = transition;
   };
 

--- a/src/PromisePipe.js
+++ b/src/PromisePipe.js
@@ -301,7 +301,7 @@ function PromisePipeFactory(){
     },
     'inherit-pipe': {
       predicate: function (sequence, data, pipe, ctx, funcArr) {
-        return funcArr._env === ctx._env;
+        return funcArr._env === ctx._env || funcArr._env === 'inherit-pipe';
       },
       handler: function (sequence, data, pipe, ctx, doWork, funcArr) {
         return doWork.then(funcArr);

--- a/tests/PromisePipe.error.spec.js
+++ b/tests/PromisePipe.error.spec.js
@@ -9,35 +9,35 @@ describe('PromisePipe with 3 functions when called', function(){
 
   var PromisePipe = require('../src/PromisePipe')();
 
-	var context = {};
-	var data1 = 1;
-	var data2 = 2;
-	var data3 = 3;
-	var fn1 = sinon.stub();
-	var fn2 = sinon.stub();
-	var fn3 = sinon.stub();
-	var finish = sinon.spy();
-	var finish1 = sinon.spy();
-	//if runninng with data1
-	//fn1.withArgs(data1, context).throws(data2);
-	fn2.withArgs(data2, context).returns(data3);
-	fn3.withArgs(data3, context).returns(data1);
+  var context = {};
+  var data1 = 1;
+  var data2 = 2;
+  var data3 = 3;
+  var fn1 = sinon.stub();
+  var fn2 = sinon.stub();
+  var fn3 = sinon.stub();
+  var finish = sinon.spy();
+  var finish1 = sinon.spy();
+  //if runninng with data1
+  //fn1.withArgs(data1, context).throws(data2);
+  fn2.withArgs(data2, context).returns(data3);
+  fn3.withArgs(data3, context).returns(data1);
 
-	var pipe = PromisePipe()
-			.then(function test(){
+  var pipe = PromisePipe()
+      .then(function test(){
         return ff()
       })
-			.then(fn2)
-			.then(fn3)
+      .then(fn2)
+      .then(fn3)
 
 
-	before(function(done){
+  before(function(done){
     hook = captureStream(process.stdout);
-		pipe(data1, context).then(finish);
-		done()
-	})
+    pipe(data1, context).then(finish);
+    done()
+  })
 
-	it('should end with final function', function(){
+  it('should end with final function', function(){
     sinon.assert.notCalled(fn2);
     sinon.assert.notCalled(fn3);
 
@@ -45,7 +45,7 @@ describe('PromisePipe with 3 functions when called', function(){
     expect(/ReferenceError: ff is not defined/.test(hook.captured())).to.be.ok;
     expect(/PromisePipe.error.spec.js:/.test(hook.captured())).to.be.ok;
     hook.unhook();
-	});
+  });
 });
 
 


### PR DESCRIPTION
Rollback to first implementation of reduce of sequence and refactor to functions with common scope. Create background for `inherit` and `both` envs.