### PR TITLE
Makes logger configurable by passing logger instance into options

### DIFF
--- a/src/PromisePipe.js
+++ b/src/PromisePipe.js
@@ -14,7 +14,8 @@ function augmentContext(context, property, value){
 
 function PromisePipeFactory(options){
   options = options || {
-    timeout: 2000
+    timeout: 2000,
+    logger: console,
   };
   /**
    * cleanup PromisePipe call ID/and env at the Pipe end
@@ -102,7 +103,6 @@ function PromisePipeFactory(options){
         }
         console.groupEnd('.then(' + name + ')');
       }
-
       if(console.group){
         showLevel(0, traceLog);
       } else {
@@ -706,7 +706,7 @@ function PromisePipeFactory(options){
         return ctx._env !== funcArr._env;
       }
 
-      //it shows error in console and passes it down
+      //it shows error in options.logger and passes it down
       function errorEnhancer(data){
         //is plain Error and was not yet caught
         if(data instanceof Error && !data.caughtOnChainId){
@@ -714,10 +714,10 @@ function PromisePipeFactory(options){
 
           var trace = stackTrace({e: data});
           if(funcArr._name) {
-            console.log('Failed inside ' + funcArr._name);
+            options.logger.log('Failed inside ' + funcArr._name);
           }
-          console.log(data.toString());
-          console.log(trace.join('\n'));
+          options.logger.log(data.toString());
+          options.logger.log(trace.join('\n'));
         }
         return Promise.reject(data);
       }

--- a/tests/PromisePipe.error.spec.js
+++ b/tests/PromisePipe.error.spec.js
@@ -48,6 +48,59 @@ describe('PromisePipe with 3 functions when called', function(){
   });
 });
 
+describe('PromisePipe with custom logger', function () {
+  var hook;
+  var logger = {
+    log: sinon.stub(),
+  };
+  var PromisePipe = require('../src/PromisePipe')({
+    logger: logger
+  });
+  var context = {};
+  var data1 = 1;
+  var data2 = 2;
+  var data3 = 3;
+  var fn1 = sinon.stub();
+  var fn2 = sinon.stub();
+  var fn3 = sinon.stub();
+  var finish = sinon.spy();
+  var finish1 = sinon.spy();
+  //if runninng with data1
+  //fn1.withArgs(data1, context).throws(data2);
+  fn2.withArgs(data2, context).returns(data3);
+  fn3.withArgs(data3, context).returns(data1);
+
+  var pipe = PromisePipe()
+    .then(function test(){
+      return ff()
+    })
+    .then(fn2)
+    .then(fn3);
+
+
+  before(function(done){
+    hook = captureStream(process.stdout);
+    pipe(data1, context).then(finish);
+    done()
+  })
+
+  after(function () {
+    hook.unhook();
+  });
+
+  it('should end with final function', function(){
+    sinon.assert.notCalled(fn2);
+    sinon.assert.notCalled(fn3);
+
+    expect(logger.log.callCount).to.be.eql(3);
+    expect(/Failed inside test/.test(logger.log.firstCall.args[0])).to.be.ok;
+    expect(/ReferenceError: ff is not defined/.test(logger.log.secondCall.args[0])).to.be.ok;
+    expect(/PromisePipe.error.spec.js:/.test(logger.log.thirdCall.args[0])).to.be.ok;
+    expect(hook.captured()).to.be.eql('');
+  });
+
+});
+
 
 function captureStream(stream){
   var oldWrite = stream.write;


### PR DESCRIPTION
This fixes #37.

By passing your custom logger into a factory method, you are now able to switch off/redirect the annoying stdout console output during error. I've left out the printDebug part as it is typically not used in production env where the console.log output bothers us. If option is not specified, it falls back to previous behavior and uses `console` as default logger.

Usage:
```javascript
PromisePipe = require('promise-pipe')({
  logger: {
    log: function () {
      return; // do nothing
    }
  }
});
```